### PR TITLE
Removing jquery from page

### DIFF
--- a/themes/raditian/layouts/partials/base-foot.html
+++ b/themes/raditian/layouts/partials/base-foot.html
@@ -9,7 +9,6 @@
     observer.observe();
   });
 </script>
-<script src='{{ "js/library/jquery-3.6.3.slim.min.js" | absURL }}'></script>
 <script src='{{ "js/library/bootstrap.min.js" | absURL }}'></script>
 <script src='{{ "js/sticky-header.js" | absURL }}'></script>
 <script src='{{ "js/library/smooth-scroll.polyfills.min.js" | absURL }}'></script>


### PR DESCRIPTION
And see what happens.

https://getbootstrap.com/docs/4.6/getting-started/introduction/
>Many of our components require the use of JavaScript to function. Specifically, they require [jQuery](https://jquery.com/), [Popper](https://popper.js.org/), and our own JavaScript plugins. We use [jQuery’s slim build](https://blog.jquery.com/2016/06/09/jquery-3-0-final-released/), but the full version is also supported.


I think I'll have to update first to bootstrap 5 (https://getbootstrap.com/docs/5.0/getting-started/javascript/)