### PR TITLE
"Updating" to 1.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/zetxek/adrianmoreno.info
 
-go 1.23
+go 1.20
 
-require github.com/zetxek/adritian-free-hugo-theme v1.4.28-0.20250125211631-64928b683f36
+require github.com/zetxek/adritian-free-hugo-theme v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/zetxek/adritian-free-hugo-theme v1.4.28-0.20250125211631-64928b683f36 h1:VdnbGxSErcORMTMdaLfPf7nXMNn3LQdl7u+QRzRtXz0=
-github.com/zetxek/adritian-free-hugo-theme v1.4.28-0.20250125211631-64928b683f36/go.mod h1:RZxMuUPx+AJwqABiHDQWSVEskypgZCqZ0MwOgCvA6o0=
+github.com/zetxek/adritian-free-hugo-theme v1.5.0 h1:N/g2BUgqnJW5Wn67noef5Lyki5esEHgriNV8es3p4/g=
+github.com/zetxek/adritian-free-hugo-theme v1.5.0/go.mod h1:RZxMuUPx+AJwqABiHDQWSVEskypgZCqZ0MwOgCvA6o0=


### PR DESCRIPTION
See https://github.com/zetxek/adritian-free-hugo-theme/discussions/171

The theme won't have a version `v2.x`, as it seems to be problematic in go modules (and therefore in hugo modules too).
