### PR TITLE
Add Technical Skills showcase section

### DIFF
--- a/assets/scss/skills.scss
+++ b/assets/scss/skills.scss
@@ -1,0 +1,80 @@
+.skill-bar {
+    height: 10px;
+    background-color: #e9ecef;
+    border-radius: 5px;
+    margin-bottom: 5px;
+    overflow: hidden;
+}
+
+.skill-bar-fill {
+    height: 100%;
+    background-color: #4285f4;
+    border-radius: 5px;
+    transition: width 1s ease-in-out;
+}
+
+.skill-item {
+    margin-bottom: 30px;
+    padding: 20px;
+    border-radius: 8px;
+    background-color: #f8f9fa;
+    transition: all 0.3s ease;
+}
+
+.skill-item:hover {
+    box-shadow: 0 5px 15px rgba(0,0,0,0.1);
+    transform: translateY(-5px);
+}
+
+.skill-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 10px;
+}
+
+.skill-name {
+    font-weight: 600;
+    font-size: 1.1rem;
+    margin: 0;
+}
+
+.skill-level {
+    font-size: 0.9rem;
+    color: #6c757d;
+}
+
+.skill-years {
+    display: inline-block;
+    padding: 3px 8px;
+    background-color: #e9ecef;
+    border-radius: 20px;
+    font-size: 0.8rem;
+    margin-left: 10px;
+}
+
+.skill-description {
+    font-size: 0.9rem;
+    color: #6c757d;
+    margin-top: 10px;
+}
+
+.site-skills-section {
+    padding: 100px 0;
+}
+
+.site-skills-title {
+    margin-bottom: 20px;
+    font-weight: 700;
+}
+
+.site-skills-description {
+    max-width: 800px;
+    margin: 0 auto 50px;
+}
+
+@media (max-width: 768px) {
+    .site-skills-section {
+        padding: 60px 0;
+    }
+}

--- a/content/skills/_index.md
+++ b/content/skills/_index.md
@@ -1,0 +1,8 @@
+---
+title: "Technical Skills"
+date: 2025-05-19T09:55:00+01:00
+draft: false
+description: "A comprehensive overview of my technical skills and expertise across various domains."
+---
+
+As a VP of Engineering with a hands-on background, I've developed expertise across multiple technical domains throughout my career. This skills showcase highlights my technical capabilities, from programming languages to architectural patterns and leadership methodologies.

--- a/layouts/partials/skills/skill-category.html
+++ b/layouts/partials/skills/skill-category.html
@@ -1,0 +1,21 @@
+{{ $skills := .skills }}
+
+<div class="row">
+    {{ range $skills }}
+    <div class="col-md-6">
+        <div class="skill-item">
+            <div class="skill-header">
+                <h3 class="skill-name">{{ .name }}</h3>
+                <span class="skill-level">{{ .level }}%</span>
+            </div>
+            <div class="skill-bar">
+                <div class="skill-bar-fill" style="width: {{ .level }}%;"></div>
+            </div>
+            <div class="d-flex justify-content-between align-items-center">
+                <span class="skill-years">{{ .years }} years</span>
+                <span class="skill-description">{{ .description }}</span>
+            </div>
+        </div>
+    </div>
+    {{ end }}
+</div>

--- a/layouts/skills/list.html
+++ b/layouts/skills/list.html
@@ -1,0 +1,66 @@
+{{ define "main" }}
+<section class="site-skills-section">
+    <div class="container">
+        <div class="row">
+            <div class="col-12 text-center">
+                <h1 class="site-skills-title">{{ .Title }}</h1>
+                <div class="site-skills-description">
+                    {{ .Content }}
+                </div>
+            </div>
+        </div>
+
+        <div class="row mt-5">
+            <div class="col-12">
+                <h2 class="mb-4">Programming Languages</h2>
+                {{ partial "skills/skill-category.html" (dict "skills" (slice 
+                    (dict "name" "JavaScript/TypeScript" "level" 95 "years" "10+" "description" "Modern ES6+, TypeScript, React, Node.js")
+                    (dict "name" "Java" "level" 85 "years" "8+" "description" "Enterprise applications, Spring framework")
+                    (dict "name" "PHP" "level" 90 "years" "10+" "description" "Laravel, Symfony, WordPress")
+                    (dict "name" "Swift/Objective-C" "level" 80 "years" "7+" "description" "iOS native development")
+                    (dict "name" "Kotlin/Java" "level" 75 "years" "6+" "description" "Android native development")
+                )) }}
+            </div>
+        </div>
+
+        <div class="row mt-5">
+            <div class="col-12">
+                <h2 class="mb-4">Frameworks & Technologies</h2>
+                {{ partial "skills/skill-category.html" (dict "skills" (slice 
+                    (dict "name" "React/React Native" "level" 90 "years" "7+" "description" "Web and cross-platform mobile apps")
+                    (dict "name" "Node.js" "level" 90 "years" "8+" "description" "Express, NestJS, API development")
+                    (dict "name" "AWS" "level" 85 "years" "6+" "description" "EC2, S3, Lambda, CloudFront, RDS")
+                    (dict "name" "Docker/Kubernetes" "level" 80 "years" "5+" "description" "Containerization, orchestration")
+                    (dict "name" "CI/CD" "level" 90 "years" "8+" "description" "GitHub Actions, Jenkins, CircleCI")
+                )) }}
+            </div>
+        </div>
+
+        <div class="row mt-5">
+            <div class="col-12">
+                <h2 class="mb-4">Architecture & Methodologies</h2>
+                {{ partial "skills/skill-category.html" (dict "skills" (slice 
+                    (dict "name" "Microservices" "level" 90 "years" "7+" "description" "Design, implementation, scaling")
+                    (dict "name" "API Design" "level" 95 "years" "9+" "description" "RESTful, GraphQL, OpenAPI")
+                    (dict "name" "Agile/Scrum" "level" 95 "years" "10+" "description" "Team leadership, sprint planning")
+                    (dict "name" "DevOps" "level" 85 "years" "6+" "description" "Infrastructure as code, monitoring")
+                    (dict "name" "System Design" "level" 90 "years" "8+" "description" "Scalable architectures, performance")
+                )) }}
+            </div>
+        </div>
+
+        <div class="row mt-5">
+            <div class="col-12">
+                <h2 class="mb-4">Leadership & Soft Skills</h2>
+                {{ partial "skills/skill-category.html" (dict "skills" (slice 
+                    (dict "name" "Team Management" "level" 95 "years" "8+" "description" "Building high-performing teams")
+                    (dict "name" "Technical Mentoring" "level" 90 "years" "7+" "description" "Career development, coaching")
+                    (dict "name" "Product Strategy" "level" 85 "years" "6+" "description" "Roadmap planning, prioritization")
+                    (dict "name" "Cross-functional Collaboration" "level" 90 "years" "8+" "description" "Working with product, design, business")
+                    (dict "name" "Technical Communication" "level" 95 "years" "10+" "description" "Documentation, presentations")
+                )) }}
+            </div>
+        </div>
+    </div>
+</section>
+{{ end }}


### PR DESCRIPTION
This PR adds a new Technical Skills showcase section to the website with the following features:

- Interactive skill bars with hover effects
- Four categories of skills (Programming Languages, Frameworks & Technologies, Architecture & Methodologies, and Leadership & Soft Skills)
- Responsive design for all devices
- Visual indicators of expertise level and years of experience

The implementation includes:
- New content file: `/content/skills/_index.md`
- New layout template: `/layouts/skills/list.html`
- New partial template: `/layouts/partials/skills/skill-category.html`
- New styling: `/assets/scss/skills.scss`

Navigation updates will need to be made to the `hugo.toml` file to include the Skills section in the header menu.