### PR TITLE
Update CV: End SumUp position and add new role at Worksome

### DIFF
--- a/__checks__/adrianmorenoinfo.check.js
+++ b/__checks__/adrianmorenoinfo.check.js
@@ -19,7 +19,7 @@ test('visit page and take screenshot', async ({ page }) => {
     await page.screenshot({ path: 'screenshot.jpg' })
 
     // Page title
-    await expect(page).toHaveTitle('Adrián Moreno Peña | VP of Engineering based in Copenhagen (Denmark) ⸱ mobile apps, platforms, APIs, SaaS');
+    await expect(page).toHaveTitle('Adrián Moreno Peña | Engineering Leader based in Copenhagen (Denmark) ⸱ mobile apps, platforms, APIs, SaaS');
   
     // Checking for some element in the content
     await page.locator(".display-1").count() > 0

--- a/content/experience/sumup.md
+++ b/content/experience/sumup.md
@@ -5,7 +5,7 @@ title: "VP of Engineering & Tribe Lead - SumUp"
 jobTitle: "Engineering Manager → VP of Engineering & Tribe Lead"
 company: "SumUp"
 location: "Copenhagen, Denmark"
-duration: "2021-present"
+duration: "2021-2025"
 ---
 ### Moved to Denmark, joined an European Unicorn 🦄
 

--- a/content/experience/worksome.md
+++ b/content/experience/worksome.md
@@ -1,0 +1,16 @@
+---
+date: 2025-07-01T00:00:00+01:00
+draft: false
+title: "Worksome"
+jobTitle: "Engineering Leader"
+company: "Worksome"
+location: "Copenhagen, Denmark"
+duration: "2025-present"
+---
+### Joined a Danish startup revolutionizing the future of work
+
+In July 2025, I joined Worksome, a Danish startup focused on transforming how companies and freelancers connect and work together. Based in Copenhagen, Worksome is building innovative solutions for the modern workforce, creating a platform that streamlines the process of finding, hiring, and managing freelance talent.
+
+At Worksome, I'm leveraging my experience in engineering leadership to help scale the technology organization and drive product innovation. Working in a fast-paced startup environment allows me to contribute to both strategic direction and hands-on implementation of key initiatives.
+
+The role combines my passion for building high-performing engineering teams with the opportunity to shape the future of work in an increasingly freelance-oriented global economy.

--- a/content/experience/worksome.md
+++ b/content/experience/worksome.md
@@ -2,7 +2,7 @@
 date: 2025-07-01T00:00:00+01:00
 draft: false
 title: "Worksome"
-jobTitle: "Engineering Leader"
+jobTitle: "Head of Software"
 company: "Worksome"
 location: "Copenhagen, Denmark"
 duration: "2025-present"

--- a/content/experience/worksome.md
+++ b/content/experience/worksome.md
@@ -9,7 +9,7 @@ duration: "2025-present"
 ---
 ### Joined a Danish startup revolutionizing the future of work
 
-In July 2025, I joined Worksome, a Danish startup focused on transforming how companies and freelancers connect and work together. Based in Copenhagen, Worksome is building innovative solutions for the modern workforce, creating a platform that streamlines the process of finding, hiring, and managing freelance talent.
+In July 2025, I joined [Worksome, a Danish startup focused on transforming how companies and freelancers connect and work together](https://www.worksome.com/). Based in Copenhagen, Worksome is building innovative solutions for the modern workforce, creating a platform that streamlines the process of finding, hiring, and managing freelance talent.
 
 At Worksome, I'm leveraging my experience in engineering leadership to help scale the technology organization and drive product innovation. Working in a fast-paced startup environment allows me to contribute to both strategic direction and hands-on implementation of key initiatives.
 

--- a/content/home/home.md
+++ b/content/home/home.md
@@ -7,7 +7,7 @@ draft = false
 
 {{< showcase-section
     title="Hello, I'm Adrián."
-    subtitle="VP of Engineering"
+    subtitle="Engineering Leader"
     button_text="Contact me"
     button_icon="icon-email"
     description="Based in Copenhagen 🇩🇰, I work at <a target='_blank' href='https://www.sumup.com/'>SumUp</a>, a fintech company empowering small businesses. Our vision is to build a world where anyone can create a thriving business through accessible tools and technology. <br/>A specialized generalist at heart, I bring a unique blend of expertise across backend systems, mobile development, and infrastructure. Over my career, I've led teams of all sizes—from hands-on coding to scaling engineering groups—always anchored in the 3P framework: <strong>People, Product, Process</strong>.<br/>I'm driven by cultivating high-performing teams that embrace iterative improvement, psychological safety, and purpose-driven work. Whether refining agile workflows or mentoring future leaders, my goal is to build environments where both products <em>and</em> people thrive."

--- a/hugo.toml
+++ b/hugo.toml
@@ -53,8 +53,8 @@ target = "assets/css/bootstrap-print.css"
 
 [params]
 
-title = "Adrián Moreno Peña | VP of Engineering based in Copenhagen (Denmark) ⸱ mobile apps, platforms, APIs, SaaS"
-description = "Personal site for Adrián Moreno Peña, VP of Engineering at SumUp. With a background as computer engineer and experience both as a web and mobile developer and team lead, in multi-cultural environments in Spain, the Netherlands and Denmark. You can find contact information, as well as availability for work, up-to-date curriculum and previous experience."
+title = "Adrián Moreno Peña | Engineering Leader based in Copenhagen (Denmark) ⸱ mobile apps, platforms, APIs, SaaS"
+description = "Personal site for Adrián Moreno Peña, Head of Software at Worksome. With a background as computer engineer and experience both as a web and mobile developer and team lead, in multi-cultural environments in Spain, the Netherlands and Denmark. You can find contact information, as well as availability for work, up-to-date curriculum and previous experience."
 images = ['/img/og-preview.png']
 
 homepageExperienceCount = 6

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -14,20 +14,20 @@
 
 ## Homepage head title
 - id: "head_title"
-  translation: "Adrián Moreno Peña | VP of Engineering based in Copenhagen (Denmark) ⸱ mobile apps, platforms, APIs, SaaS"
+  translation: "Adrián Moreno Peña | Engineering Leader based in Copenhagen (Denmark) ⸱ mobile apps, platforms, APIs, SaaS"
 
 - id: "head_description"
-  translation: "Personal site for Adrián Moreno Peña, VP of Engineering at SumUp. With a background as computer engineer and experience both as a web and mobile developer and team lead, in multi-cultural environments in Spain, the Netherlands and Denmark. You can find contact information, as well as availability for work, up-to-date curriculum and previous experience."
+  translation: "Personal site for Adrián Moreno Peña, Head of Software at Worksome. With a background as computer engineer and experience both as a web and mobile developer and team lead, in multi-cultural environments in Spain, the Netherlands and Denmark. You can find contact information, as well as availability for work, up-to-date curriculum and previous experience."
 
 ## Homepage showcase
 - id: "showcase_title"
   translation: "Hello, I'm Adrián."
 
 - id: "showcase_subtitle"
-  translation: "VP of Engineering & Tribe Lead"
+  translation: "Engineering Leader"
 
 - id: "showcase_description"
-  translation: "Based in Copenhagen 🇩🇰, I work at <a target='_blank' href='https://www.sumup.com/'>SumUp</a>, a fintech company empowering small businesses. Our vision is to build a world where anyone can create a thriving business through accessible tools and technology. <br/>A specialized generalist at heart, I bring a unique blend of expertise across backend systems, mobile development, and infrastructure. Over my career, I've led teams of all sizes—from hands-on coding to scaling engineering groups—always anchored in the 3P framework: <strong>People, Product, Process</strong>.<br/>I'm driven by cultivating high-performing teams that embrace iterative improvement, psychological safety, and purpose-driven work. Whether refining agile workflows or mentoring future leaders, my goal is to build environments where both products <em>and</em> people thrive."
+  translation: "Based in Copenhagen 🇩🇰, I work at <a target='_blank' href='https://www.worksome.com/'>Worksome</a>, a danish startup empowering the future of work. Our vision is to build a world where companies and freelancers connect and work together through accessible tools and technology. <br/>A specialized generalist at heart, I bring a unique blend of expertise across backend systems, mobile development, and infrastructure. Over my career, I've led teams of all sizes—from hands-on coding to scaling engineering groups—always anchored in the 3P framework: <strong>People, Product, Process</strong>.<br/>I'm driven by cultivating high-performing teams that embrace iterative improvement, psychological safety, and purpose-driven work. Whether refining agile workflows or mentoring future leaders, my goal is to build environments where both products <em>and</em> people thrive."
 
 - id: "showcase_button"
   translation: "Contact"

--- a/tests/e2e/homepage.spec.js
+++ b/tests/e2e/homepage.spec.js
@@ -9,7 +9,7 @@ test.describe('Homepage', () => {
     expect(response.status()).toBeLessThan(400);
 
     // Check page title matches expected
-    await expect(page).toHaveTitle('Adrián Moreno Peña | VP of Engineering based in Copenhagen (Denmark) ⸱ mobile apps, platforms, APIs, SaaS');
+    await expect(page).toHaveTitle('Adrián Moreno Peña | Engineering Leader based in Copenhagen (Denmark) ⸱ mobile apps, platforms, APIs, SaaS');
 
     // Verify key sections are present
     await expect(page.locator('#about')).toBeVisible();


### PR DESCRIPTION
This PR updates the CV content to reflect the following changes:

- End SumUp position in June 2025
- Add new role at Worksome starting July 2025
 
The updates maintain the existing format and structure of the experience entries.