### PR TITLE
chore: update adritian-free-hugo-theme v1.9.8 -> v1.9.11

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,4 +5,4 @@ go 1.20
 // for local development
 // replace github.com/zetxek/adritian-free-hugo-theme => ../adritian-free-hugo-theme
 
-require github.com/zetxek/adritian-free-hugo-theme v1.9.8 // indirect
+require github.com/zetxek/adritian-free-hugo-theme v1.9.11 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/zetxek/adritian-free-hugo-theme v1.9.8 h1:Gv2lUmdQ5FhxfZYPU7Dupt593c0nQPsTzp4B1pSBcJo=
-github.com/zetxek/adritian-free-hugo-theme v1.9.8/go.mod h1:RZxMuUPx+AJwqABiHDQWSVEskypgZCqZ0MwOgCvA6o0=
+github.com/zetxek/adritian-free-hugo-theme v1.9.11 h1:TaboXLBUtxE6wuFI3xe+jeSiD3RJsRxqAEEqCD/bev8=
+github.com/zetxek/adritian-free-hugo-theme v1.9.11/go.mod h1:RZxMuUPx+AJwqABiHDQWSVEskypgZCqZ0MwOgCvA6o0=


### PR DESCRIPTION
🤖 This automated PR updates the Hugo modules to their latest versions.

Changes in go.mod:
```
+require github.com/zetxek/adritian-free-hugo-theme v1.9.11 // indirect
```

🔗 Triggered by GitHub action: https://github.com/zetxek/adrianmoreno.info/actions/workflows/update-hugo-modules.yml