### PR TITLE
chore: update adritian-free-hugo-theme unknown -> v1.10.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,4 +5,4 @@ go 1.20
 // for local development
 // replace github.com/zetxek/adritian-free-hugo-theme => ../adritian-free-hugo-theme
 
-require github.com/zetxek/adritian-free-hugo-theme v1.10.0 // indirect
+require github.com/zetxek/adritian-free-hugo-theme v1.10.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,2 @@
-github.com/zetxek/adritian-free-hugo-theme v1.9.16-0.20260714184409-edcd0b6c228d h1:VmzugtUDHn5zwx9i3I/8ijdx4pFZa7UldY7rEkNexQA=
-github.com/zetxek/adritian-free-hugo-theme v1.9.16-0.20260714184409-edcd0b6c228d/go.mod h1:RZxMuUPx+AJwqABiHDQWSVEskypgZCqZ0MwOgCvA6o0=
-github.com/zetxek/adritian-free-hugo-theme v1.10.0 h1:qmtxoJeEAFN89y1JWgxxkMcVhg/nmMxDssCeKytVfec=
-github.com/zetxek/adritian-free-hugo-theme v1.10.0/go.mod h1:RZxMuUPx+AJwqABiHDQWSVEskypgZCqZ0MwOgCvA6o0=
+github.com/zetxek/adritian-free-hugo-theme v1.10.1 h1:j6zt1Wg0OREYhdOAEd9Lqbst3PpPP3SE1uJ78y4m+8k=
+github.com/zetxek/adritian-free-hugo-theme v1.10.1/go.mod h1:RZxMuUPx+AJwqABiHDQWSVEskypgZCqZ0MwOgCvA6o0=


### PR DESCRIPTION
🤖 This automated PR updates the Hugo modules to their latest versions.

Changes in go.mod:
```
+require github.com/zetxek/adritian-free-hugo-theme v1.10.1 // indirect
```

🔗 Triggered by GitHub action: https://github.com/zetxek/adrianmoreno.info/actions/workflows/update-hugo-modules.yml