### PR TITLE
draft: It's Not an Attack — It's a Gift They Can't Open Without You

### DIFF
--- a/content/blog/2026-07-21-feedback-isnt-attack-its-a-gift.md
+++ b/content/blog/2026-07-21-feedback-isnt-attack-its-a-gift.md
@@ -44,7 +44,7 @@ Scott maps out four quadrants:
 
 - **Obnoxious Aggression**: challenge directly, don't care personally. This is what people are afraid of being. It *is* attacking. Don't be this.
 - **Ruinous Empathy**: care personally, don't challenge directly. This is what most people default to. You care so much about not hurting their feelings that you let them walk off a cliff. This is the real trap.
-- **Manipulative Insincerity**: neither care nor challenge. Office politics. Talking behind backs. The worst of all worlds.
+- **Manipulative Insincerity**: neither care nor challenge. Office politics. Talking behind people's backs. The worst of all worlds.
 - **Radical Candor**: both. The goal.
 
 Most first-time managers I've coached live in Ruinous Empathy. They're kind people. They don't want to hurt anyone. So they say nothing — and the person they're protecting keeps making the same mistake, month after month, while their reputation quietly erodes.

--- a/content/blog/2026-07-21-feedback-isnt-attack-its-a-gift.md
+++ b/content/blog/2026-07-21-feedback-isnt-attack-its-a-gift.md
@@ -1,0 +1,90 @@
++++
+title = "It's Not an Attack — It's a Gift They Can't Open Without You"
+slug = "feedback-isnt-attack-its-a-gift"
+date = "2026-07-21T12:00:00+02:00"
+draft = true
+tags = ["article", "feedback", "leadership", "management", "radical candor"]
+categories = ["Leadership & Culture"]
+layout = "blog"
++++
+
+"It's probably just my opinion."
+
+"I don't want to sound like I'm attacking them."
+
+"They probably already know."
+
+I've heard every variation of this. Mostly from first-time managers. Sometimes from experienced ones. The words change but the feeling underneath is the same: **I have something to say, and I'm afraid saying it will make things worse.**
+
+If you've felt this, you're not broken. You're human. And getting past it is one of the most important things you'll ever do as a leader.
+
+---
+
+### The Real Cost of Staying Silent
+
+Here's the reframe that changes everything: **withholding feedback isn't protecting them — it's robbing them.**
+
+You noticed something. Maybe it's how they interrupted three people in that meeting. Maybe it's the way their presentation buried the main point under twelve slides of context. Maybe they're burning goodwill with a stakeholder and don't realize it.
+
+If you noticed — others did too. Most people don't give feedback. They just silently adjust their opinion of the person downward. They stop inviting them to meetings. They route around them.
+
+You have a chance to give this person something nobody else will: a clear, caring observation that helps them grow. **Why would you take that away from someone you care about?**
+
+Silencing that observation doesn't help them. It helps *you* — by letting you avoid an uncomfortable conversation. That's not caring. That's convenience dressed up as kindness.
+
+---
+
+### The Framework That Makes It Click
+
+Kim Scott's [Radical Candor](https://www.radicalcandor.com) framework is the best tool I've found for this. It's not complicated: **care personally, challenge directly.**
+
+The mistake people make is assuming these two things are in tension. They're not. The most caring thing you can do for someone is tell them the truth. And the most effective way to challenge someone is to do it from a place of genuine care.
+
+Scott maps out four quadrants:
+
+- **Obnoxious Aggression**: challenge directly, don't care personally. This is what people are afraid of being. It *is* attacking. Don't be this.
+- **Ruinous Empathy**: care personally, don't challenge directly. This is what most people default to. You care so much about not hurting their feelings that you let them walk off a cliff. This is the real trap.
+- **Manipulative Insincerity**: neither care nor challenge. Office politics. Talking behind backs. The worst of all worlds.
+- **Radical Candor**: both. The goal.
+
+Most first-time managers I've coached live in Ruinous Empathy. They're kind people. They don't want to hurt anyone. So they say nothing — and the person they're protecting keeps making the same mistake, month after month, while their reputation quietly erodes.
+
+**That's not kindness. That's neglect.**
+
+---
+
+### How to Say It Without Attacking
+
+The difference between Radical Candor and Obnoxious Aggression isn't the message. It's the intent — and how you deliver it. Here's what works:
+
+**Lead with care, not correction.** Before you say anything, ask yourself: *am I saying this because I want to help them, or because I'm annoyed and want to vent?* If it's the second one, wait. Come back when you're calm enough to mean the first one.
+
+**Be specific, not sweeping.** "You're bad at presentations" is an attack. "In yesterday's meeting, you spent ten minutes on context before stating your recommendation — I think people tuned out before the important part" is a gift. Specific, observable, actionable.
+
+**Ask, don't declare.** End with a question. "Is that something you've noticed?" or "How does that land with you?" This turns a monologue into a conversation. It signals that you're not delivering a verdict — you're sharing an observation and inviting their perspective.
+
+**Make it about the work, not the person.** "The presentation buried the lead" is about the output. "You're a bad communicator" is about identity. Stay on the output.
+
+**Say why you're saying it.** "I'm telling you this because I've seen how good you are at X, and I think if you fix Y, you'll be unstoppable." Give them the context that proves your intent.
+
+---
+
+### The Test: Would You Want to Know?
+
+Here's the question I come back to when I'm hesitating:
+
+**If I were making this mistake, would I want someone to tell me?**
+
+The answer is always yes. Every time. I'd rather hear it from someone who cares about me than discover it six months later in a performance review or — worse — never discover it at all, and wonder why opportunities stopped coming.
+
+So when you're afraid of sounding like you're attacking: ask yourself who you're really protecting. Is it them? Or is it you?
+
+Giving feedback isn't easy. It never gets easy. But it gets easier — and it's one of the few things that separates good managers from great ones.
+
+If you noticed it, say it. With care. With specifics. With their growth in mind.
+
+**That's not attacking. That's leading.**
+
+---
+
+*I've [written before]({{< ref "/blog/2024-10-29-nice-and-did-you-tell-them.md" >}}) about the habit of hoarding feedback instead of delivering it, and about [building credibility]({{< ref "/blog/2022-04-29-do-you-know-that-kind-of-online-profile-that-on.md" >}}) so your feedback lands. This is the deeper layer — the fear underneath the silence.*

--- a/content/blog/2026-07-21-feedback-isnt-attack-its-a-gift.md
+++ b/content/blog/2026-07-21-feedback-isnt-attack-its-a-gift.md
@@ -8,13 +8,13 @@ categories = ["Leadership & Culture"]
 layout = "blog"
 +++
 
-"It's probably just my opinion."
+"It's probably just my opinion, what do I know."
 
 "I don't want to sound like I'm attacking them."
 
 "They probably already know."
 
-I've heard every variation of this. Mostly from first-time managers. Sometimes from experienced ones. The words change but the feeling underneath is the same: **I have something to say, and I'm afraid saying it will make things worse.**
+I've heard every variation of this -  mostly from first-time managers. Sometimes from experienced ones. The words change, but the feeling underneath is the same: **I have observed something, I have something to say about it, and I'm afraid saying it will make things worse.**
 
 If you've felt this, you're not broken. You're human. And getting past it is one of the most important things you'll ever do as a leader.
 

--- a/content/blog/2026-07-21-feedback-isnt-attack-its-a-gift.md
+++ b/content/blog/2026-07-21-feedback-isnt-attack-its-a-gift.md
@@ -36,7 +36,7 @@ Silencing that observation doesn't help them. It helps *you* — by letting you 
 
 ### The Framework That Makes It Click
 
-Kim Scott's [Radical Candor](https://www.radicalcandor.com) framework is the best tool I've found for this. It's not complicated: **care personally, challenge directly.**
+Kim Scott's [Radical Candor]({{< ref "/book/radical-candor.md" >}}) framework (and her [website](https://www.radicalcandor.com)) is the best tool I've found for this. It's not complicated: **care personally, challenge directly.**
 
 The mistake people make is assuming these two things are in tension. They're not. The most caring thing you can do for someone is tell them the truth. And the most effective way to challenge someone is to do it from a place of genuine care.
 


### PR DESCRIPTION
Draft article about the fear of giving feedback — especially for first-time managers. Covers the Radical Candor framework (Kim Scott), the Ruinous Empathy trap, and five practical tactics for delivering feedback without it feeling like an attack.

Links to two previous posts on feedback from Adrián's blog.

Set as `draft = true`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Content**
  * Added a new draft blog post reframing withheld feedback as a deprivation rather than an attack.
  * Introduces the “Radical Candor” care/challenge framework and provides practical guidance for delivering feedback without attacking.
  * Includes related article links and a concluding call to action.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->