### PR TITLE
test: make dependency-manifest spec version-agnostic

### DIFF
--- a/tests/e2e/dependency-manifest.spec.js
+++ b/tests/e2e/dependency-manifest.spec.js
@@ -1,11 +1,23 @@
 /**
- * Regression tests for the `fuse.js` dependency bump (package.json / package-lock.json).
+ * Dependency manifest consistency tests.
  *
- * These tests don't require a running Hugo server or a browser - they validate
- * that the dependency manifest (`package.json`) and the lockfile
- * (`package-lock.json`) are internally consistent for the `fuse.js` package,
- * guarding against lockfile drift, malformed URLs/integrity hashes, or an
- * accidental revert to the previous version.
+ * These tests are version-agnostic — they contain no hardcoded package names
+ * or version literals. Instead, they read `package.json` and `package-lock.json`
+ * at repo root and verify, for every declared dependency:
+ *
+ *  1. The lockfile root package (`packages['']`) declares the exact same range
+ *     string as `package.json` (no manifest drift).
+ *  2. A `packages['node_modules/<name>']` entry exists in the lockfile.
+ *  3. That entry's `version` satisfies the range declared in `package.json`
+ *     (caret ranges `^x.y.z` and exact pins `x.y.z` are both supported).
+ *  4. That entry has a non-empty `resolved` URL and `integrity` hash.
+ *
+ * Additionally, the reverse direction is checked: no dependency should appear
+ * in the lockfile root that is absent from `package.json` (lockfile drift
+ * without a corresponding manifest entry).
+ *
+ * These tests don't require a running Hugo server or a browser — they are pure
+ * Node `fs`/JSON assertions and run in milliseconds.
  */
 
 const { test, expect } = require('@playwright/test');
@@ -19,11 +31,22 @@ const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
 const packageLock = JSON.parse(fs.readFileSync(packageLockPath, 'utf8'));
 
 /**
- * Minimal caret-range (`^x.y.z`) satisfaction check, sufficient for the
- * ranges used in this project's dependencies. Avoids pulling in a `semver`
- * dependency just for these tests.
+ * Check whether a concrete version satisfies a semver range.
+ *
+ * Supports caret ranges (`^x.y.z`) and exact pins (`x.y.z`).
+ * Avoids pulling in a `semver` dependency just for these tests.
+ *
+ * @param {string} version - concrete version, e.g. "7.5.0"
+ * @param {string} range   - range string from package.json, e.g. "^7.5.0" or "7.5.0"
+ * @returns {boolean}
  */
-function satisfiesCaretRange(version, range) {
+function satisfiesRange(version, range) {
+  // Exact pin (no caret, no tilde, no comparator) — version must match exactly.
+  if (/^\d+\.\d+\.\d+/.test(range)) {
+    return version === range;
+  }
+
+  // Caret range ^x.y.z
   const match = /^\^(\d+)\.(\d+)\.(\d+)$/.exec(range);
   if (!match) {
     throw new Error(`Unsupported range format: ${range}`);
@@ -46,88 +69,115 @@ function satisfiesCaretRange(version, range) {
   return vPatch >= patch;
 }
 
-test.describe('package.json - fuse.js dependency', () => {
-  test('declares fuse.js with the expected caret range', () => {
-    // Array form: a plain 'fuse.js' string would be parsed as the nested
-    // path dependencies.fuse.js instead of the literal key "fuse.js".
-    expect(packageJson.dependencies).toHaveProperty(['fuse.js']);
-    expect(packageJson.dependencies['fuse.js']).toBe('^7.5.0');
+// ---------------------------------------------------------------------------
+// Collect all declared dependencies from package.json (runtime + dev).
+// ---------------------------------------------------------------------------
+
+const pkgDeps = {
+  ...(packageJson.dependencies || {}),
+  ...(packageJson.devDependencies || {}),
+};
+const pkgDepNames = Object.keys(pkgDeps);
+
+// Lockfile root package entry.
+const rootPkg = packageLock.packages[''];
+const rootDeps = {
+  ...(rootPkg.dependencies || {}),
+  ...(rootPkg.devDependencies || {}),
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+test.describe('dependency manifest consistency', () => {
+  test.describe('package.json ↔ package-lock.json root ranges', () => {
+    for (const name of pkgDepNames) {
+      test(`lockfile root declares the same range for "${name}"`, () => {
+        expect(rootDeps).toHaveProperty([name]);
+        expect(rootDeps[name]).toBe(pkgDeps[name]);
+      });
+    }
   });
 
-  test('does not still point at the previous 7.4.2 range', () => {
-    expect(packageJson.dependencies['fuse.js']).not.toBe('^7.4.2');
+  test.describe('lockfile node_modules entries', () => {
+    for (const name of pkgDepNames) {
+      const lockKey = `node_modules/${name}`;
+
+      test(`"${name}" has a lockfile entry at ${lockKey}`, () => {
+        expect(packageLock.packages[lockKey]).toBeDefined();
+      });
+
+      test(`"${name}" locked version satisfies the declared range`, () => {
+        const entry = packageLock.packages[lockKey];
+        expect(entry).toBeDefined();
+        expect(satisfiesRange(entry.version, pkgDeps[name])).toBe(true);
+      });
+
+      test(`"${name}" has a non-empty resolved URL`, () => {
+        const entry = packageLock.packages[lockKey];
+        expect(entry).toBeDefined();
+        expect(typeof entry.resolved).toBe('string');
+        expect(entry.resolved.length).toBeGreaterThan(0);
+      });
+
+      test(`"${name}" has a non-empty integrity hash`, () => {
+        const entry = packageLock.packages[lockKey];
+        expect(entry).toBeDefined();
+        expect(typeof entry.integrity).toBe('string');
+        expect(entry.integrity.length).toBeGreaterThan(0);
+      });
+    }
   });
 
-  test('other existing dependencies were left untouched by the bump', () => {
-    expect(packageJson.dependencies).toMatchObject({
-      dompurify: '^3.4.12',
-      'node-gyp': '^13.0.1',
-      playwright: '^1.62.0',
+  test.describe('reverse drift: lockfile root ↔ package.json', () => {
+    test('no lockfile root dependencies are absent from package.json', () => {
+      const rootOnly = Object.keys(rootDeps).filter(
+        (name) => !(name in pkgDeps)
+      );
+      expect(rootOnly).toEqual([]);
     });
   });
 });
 
-test.describe('package-lock.json - fuse.js entry', () => {
-  test('root package declares the same fuse.js range as package.json', () => {
-    const rootPackage = packageLock.packages[''];
-    expect(rootPackage).toBeDefined();
-    expect(rootPackage.dependencies['fuse.js']).toBe(packageJson.dependencies['fuse.js']);
+// ---------------------------------------------------------------------------
+// Helper unit tests — keep the satisfiesRange helper honest.
+// ---------------------------------------------------------------------------
+
+test.describe('satisfiesRange helper', () => {
+  test('caret: accepts an equal version', () => {
+    expect(satisfiesRange('7.5.0', '^7.5.0')).toBe(true);
   });
 
-  test('node_modules/fuse.js is pinned to version 7.5.0', () => {
-    const fuseEntry = packageLock.packages['node_modules/fuse.js'];
-    expect(fuseEntry).toBeDefined();
-    expect(fuseEntry.version).toBe('7.5.0');
+  test('caret: accepts a higher patch version within the same minor', () => {
+    expect(satisfiesRange('7.5.1', '^7.5.0')).toBe(true);
   });
 
-  test('resolved tarball URL matches the pinned version', () => {
-    const fuseEntry = packageLock.packages['node_modules/fuse.js'];
-    expect(fuseEntry.resolved).toBe(
-      'https://registry.npmjs.org/fuse.js/-/fuse.js-7.5.0.tgz'
-    );
-    // The version embedded in the tarball filename must match the "version" field.
-    expect(fuseEntry.resolved).toContain(`fuse.js-${fuseEntry.version}.tgz`);
+  test('caret: accepts a higher minor version within the same major', () => {
+    expect(satisfiesRange('7.6.0', '^7.5.0')).toBe(true);
   });
 
-  test('integrity hash is present and well-formed', () => {
-    const fuseEntry = packageLock.packages['node_modules/fuse.js'];
-    expect(fuseEntry.integrity).toBe(
-      'sha512-sQtrEfA+ez/3G0cCZecF70oqpCRttCexYUG4mUrtWL49ULUzUyxokt5kyqwtKzj1270RaKih+hcP3qLcumccow=='
-    );
-    expect(fuseEntry.integrity).toMatch(/^sha512-[A-Za-z0-9+/]+={0,2}$/);
+  test('caret: rejects a lower version than the range floor', () => {
+    expect(satisfiesRange('7.4.9', '^7.5.0')).toBe(false);
   });
 
-  test('pinned version satisfies the range declared in package.json', () => {
-    const fuseEntry = packageLock.packages['node_modules/fuse.js'];
-    const range = packageJson.dependencies['fuse.js'];
-    expect(satisfiesCaretRange(fuseEntry.version, range)).toBe(true);
+  test('caret: rejects a different major version', () => {
+    expect(satisfiesRange('8.0.0', '^7.5.0')).toBe(false);
   });
 
-  test('pinned version does not regress to the previous 7.4.2 release', () => {
-    const fuseEntry = packageLock.packages['node_modules/fuse.js'];
-    expect(fuseEntry.version).not.toBe('7.4.2');
+  test('caret: for 0.x, rejects a different minor', () => {
+    expect(satisfiesRange('0.2.0', '^0.1.5')).toBe(false);
   });
 
-  test('license metadata for fuse.js is preserved', () => {
-    const fuseEntry = packageLock.packages['node_modules/fuse.js'];
-    expect(fuseEntry.license).toBe('Apache-2.0');
-  });
-});
-
-test.describe('satisfiesCaretRange helper', () => {
-  test('accepts an equal version', () => {
-    expect(satisfiesCaretRange('7.5.0', '^7.5.0')).toBe(true);
+  test('caret: for 0.x, accepts a higher patch in same minor', () => {
+    expect(satisfiesRange('0.1.9', '^0.1.5')).toBe(true);
   });
 
-  test('accepts a higher patch/minor version within the same major', () => {
-    expect(satisfiesCaretRange('7.6.1', '^7.5.0')).toBe(true);
+  test('exact pin: accepts a matching version', () => {
+    expect(satisfiesRange('5.3.8', '5.3.8')).toBe(true);
   });
 
-  test('rejects a lower version than the range floor', () => {
-    expect(satisfiesCaretRange('7.4.2', '^7.5.0')).toBe(false);
-  });
-
-  test('rejects a different major version', () => {
-    expect(satisfiesCaretRange('8.0.0', '^7.5.0')).toBe(false);
+  test('exact pin: rejects a non-matching version', () => {
+    expect(satisfiesRange('5.3.9', '5.3.8')).toBe(false);
   });
 });

--- a/tests/e2e/dependency-manifest.spec.js
+++ b/tests/e2e/dependency-manifest.spec.js
@@ -60,7 +60,11 @@ function satisfiesRange(version, range) {
 
   if (vMajor !== major) return false;
   if (vMajor === 0) {
-    // For 0.x, caret ranges only allow patch bumps within the same minor.
+    // For 0.0.x, caret ranges pin the exact version (semver: ^0.0.5 := =0.0.5).
+    if (minor === 0) {
+      return vMinor === 0 && vPatch === patch;
+    }
+    // For 0.x.y (x > 0), caret ranges only allow patch bumps within the same minor.
     if (vMinor !== minor) return false;
     return vPatch >= patch;
   }
@@ -171,6 +175,18 @@ test.describe('satisfiesRange helper', () => {
 
   test('caret: for 0.x, accepts a higher patch in same minor', () => {
     expect(satisfiesRange('0.1.9', '^0.1.5')).toBe(true);
+  });
+
+  test('caret: for 0.0.x, accepts only the exact version', () => {
+    expect(satisfiesRange('0.0.5', '^0.0.5')).toBe(true);
+  });
+
+  test('caret: for 0.0.x, rejects a higher patch', () => {
+    expect(satisfiesRange('0.0.6', '^0.0.5')).toBe(false);
+  });
+
+  test('caret: for 0.0.x, rejects a higher minor', () => {
+    expect(satisfiesRange('0.1.0', '^0.0.5')).toBe(false);
   });
 
   test('exact pin: accepts a matching version', () => {


### PR DESCRIPTION
## Problem

`tests/e2e/dependency-manifest.spec.js` was written as a regression test for one specific dependabot PR (fuse.js 7.4.2 → 7.5.0) and hardcoded expected versions of *other* dependencies (`playwright: ^1.62.0`, etc.). Every dependency bump that lands on main makes the guard fail on unrelated dependabot PRs — it broke CI on both #468 and #469.

## New strategy

Keep the real value (package.json ↔ package-lock.json consistency), drop all per-version pins:

- Every dependency (deps + devDeps) in `package.json` must appear in the lockfile root with the **identical range string**
- Every dependency must have a `node_modules/<name>` lockfile entry whose version **satisfies its declared range** (caret ranges and exact pins), with non-empty `resolved` URL and `integrity` hash
- Reverse drift: no lockfile root entries missing from `package.json`
- Zero hardcoded package names/versions — everything derived from the two manifests

## Verification

- 200/200 passed locally (Chrome + Firefox projects)
- Negative path confirmed: corrupting `node_modules/fuse.js` to a non-satisfying version fails exactly the expected assertions, then 200/200 again after restore

Once merged, `@dependabot rebase` on #469 (and any other red dependabot PRs) picks this up.

🤖 Prepared by @zetxek using an AI coding agent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Replaced package-specific dependency checks with comprehensive manifest consistency coverage.
  * Added validation for dependency ranges, installed versions, lockfile entries, resolved URLs, integrity hashes, and reverse dependency changes.
  * Expanded version-range testing to support both caret ranges and exact version pins.
  * Removed checks tied exclusively to a single package’s version, license, URL, and integrity details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->