### PR TITLE
fix: newsletter workflow unit tests — use glob for node --test

### DIFF
--- a/.github/workflows/newsletter.yml
+++ b/.github/workflows/newsletter.yml
@@ -9,6 +9,7 @@ on:
       # package.json test script must trigger a run too.
       - 'tests/unit/**'
       - 'package.json'
+      - '.github/workflows/newsletter.yml'
   # Posts are often future-dated, so a push alone is not enough — the post may
   # not be published yet at push time, and nothing would re-trigger later.
   schedule:

--- a/.github/workflows/newsletter.yml
+++ b/.github/workflows/newsletter.yml
@@ -5,6 +5,10 @@ on:
     branches: [main]
     paths:
       - 'content/blog/**'
+      # The unit tests gate this workflow, so changes to them or to the
+      # package.json test script must trigger a run too.
+      - 'tests/unit/**'
+      - 'package.json'
   # Posts are often future-dated, so a push alone is not enough — the post may
   # not be published yet at push time, and nothing would re-trigger later.
   schedule:

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "test": "npm run test:e2e",
     "test:e2e": "playwright test",
     "test:e2e:install": "playwright install",
-    "test:unit": "node --test tests/unit/",
+    "test:unit": "node --test \"tests/unit/**/*.test.mjs\"",
     "newsletter:send": "node scripts/newsletter/send.mjs",
     "newsletter:dry-run": "node scripts/newsletter/send.mjs --dry-run",
     "cv:dev": "hugo serve",


### PR DESCRIPTION
## Root cause

`package.json` defined:

```
"test:unit": "node --test tests/unit/"
```

On Node 22 (the runner used v22.23.1), passing a **bare directory** to `node --test` no longer scans it — Node treats the path as a module entry point and fails with:

```
Error: Cannot find module '/home/runner/work/adrianmoreno.info/adrianmoreno.info/tests/unit'
```

The directory exists in the checkout; the argument form is the problem. Reproduced locally on Node v22.22.

## Impact

The newsletter workflow has failed on **every run since #464** (Aug 8) — the initial push and all daily scheduled runs — so the Resend draft-broadcast pipeline has been dead for 3 days. Example failed run: https://github.com/zetxek/adrianmoreno.info/actions/runs/31477161336

## Fix

- `test:unit` now passes an explicit glob, expanded by Node internally (shell- and OS-agnostic):

```
"test:unit": "node --test \"tests/unit/**/*.test.mjs\""
```

- `newsletter.yml` push trigger now also fires on `tests/unit/**` and `package.json` changes, so a broken test script is caught by the push that breaks it instead of the next daily cron.

## Verification

`npm run test:unit` → **66 pass / 0 fail** (Node v22.22.0).

---
🤖 Prepared by @zetxek via an AI coding agent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved automated unit test discovery across nested test directories.
  - Automated validation now runs when unit tests or project configuration change, helping ensure updates are checked consistently.

- **Chores**
  - Updated the project’s test command to use the current test-running approach for more reliable execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->