### PR TITLE
blog: opt SaaSpocalypse post into newsletter

### DIFF
--- a/content/blog/2026-08-22-the-saaspocalypse-that-never-came.md
+++ b/content/blog/2026-08-22-the-saaspocalypse-that-never-came.md
@@ -9,7 +9,7 @@ layout = "blog"
 images = ["/images/blog/the-saaspocalypse-that-never-came.jpg"]
 featuredImage = "/images/blog/the-saaspocalypse-that-never-came.jpg"
 # Set to true to email this post to newsletter subscribers when it goes live.
-newsletter = false
+newsletter = true
 +++
 
 Remember the SaaSpocalypse?


### PR DESCRIPTION
## What

Sets `newsletter = true` in the frontmatter of `2026-08-22-the-saaspocalypse-that-never-came.md`.

## Why

Newsletter run [32581237598](https://github.com/zetxek/adrianmoreno.info/actions/runs/32581237598) reported "No posts qualify" — no post in `content/blog/` had the opt-in flag (the archetype defaults to `false`).

## What happens on merge

Merging to `main` touches `content/blog/**`, which auto-triggers the Newsletter workflow. The post passes all four qualification checks (`newsletter = true`, not draft, date in the past, not in `.newsletter-state.json`), so the run will create a **draft** broadcast in Resend — nothing is emailed until you press Send there.

---

🤖 Prepared by @zetxek via an AI coding agent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled newsletter distribution for the “The SaaSpocalypse That Never Came” blog post.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->