### PR TITLE
fix(newsletter): bound broadcast name to Resend's 70-char limit

### DIFF
--- a/scripts/newsletter/send.mjs
+++ b/scripts/newsletter/send.mjs
@@ -79,7 +79,10 @@ async function main() {
         segmentId: requireEnv('RESEND_SEGMENT_ID'),
         from: requireEnv('NEWSLETTER_FROM'),
         subject: post.title,
-        name: `${post.date?.slice(0, 10) ?? ''} ${post.title}`.trim(),
+        // Resend caps `name` at 70 characters (422 otherwise). It is only an
+        // internal dashboard label — recipients see `subject` — so truncating
+        // is safe.
+        name: `${post.date?.slice(0, 10) ?? ''} ${post.title}`.trim().slice(0, 70),
         html,
       });
 


### PR DESCRIPTION
## Problem

Newsletter run [32586225088](https://github.com/zetxek/adrianmoreno.info/actions/runs/32586225088) failed at the Resend API:

```
Resend broadcast creation failed (422): Field `name` has a maximum of 70 items.
```

`send.mjs` builds the broadcast `name` as `date + title`. For the SaaSpocalypse post that's 78 chars → 422.

## Fix

Truncate the composed `name` to 70 chars. `name` is only Resend's internal dashboard label — recipients see `subject` (the full title), which is untouched.

## After merge

The workflow's path triggers don't cover `scripts/**`, so merging won't auto-run it. The failed post was **not** recorded in `.newsletter-state.json`, so it will retry on the next run — either tomorrow's 09:00 UTC schedule, or a manual dispatch with `dry_run=false`.

---

🤖 Prepared by @zetxek via an AI coding agent.