### PR TITLE
fix(newsletter): emit Resend unsubscribe merge tag literally

### DIFF
--- a/.newsletter-state.json
+++ b/.newsletter-state.json
@@ -1,5 +1,3 @@
 {
-  "sent": [
-    "the-saaspocalypse-that-never-came"
-  ]
+  "sent": []
 }

--- a/layouts/blog/single.email.html
+++ b/layouts/blog/single.email.html
@@ -60,7 +60,7 @@
       <a href="{{ .Site.BaseURL }}">adrianmoreno.info</a>.
     </p>
     <p>
-      <a href="{{ "{{{RESEND_UNSUBSCRIBE_URL}}}" | safeHTML }}">Unsubscribe</a>
+      <a href="{{ "{{{RESEND_UNSUBSCRIBE_URL}}}" | safeURL }}">Unsubscribe</a>
       &middot;
       <a href="{{ "privacy/" | absURL }}">Privacy</a>
     </p>

--- a/layouts/blog/single.email.html
+++ b/layouts/blog/single.email.html
@@ -60,7 +60,7 @@
       <a href="{{ .Site.BaseURL }}">adrianmoreno.info</a>.
     </p>
     <p>
-      <a href="{{ "{{{RESEND_UNSUBSCRIBE_URL}}}" | safeURL }}">Unsubscribe</a>
+      {{ printf "<a href=\"{{{RESEND_UNSUBSCRIBE_URL}}}\">Unsubscribe</a>" | safeHTML }}
       &middot;
       <a href="{{ "privacy/" | absURL }}">Privacy</a>
     </p>

--- a/scripts/newsletter/send.mjs
+++ b/scripts/newsletter/send.mjs
@@ -33,7 +33,14 @@ function emailHtmlFor(slug) {
     );
   }
   // Inline the <style> block: Gmail and Outlook treat head styles inconsistently.
-  return juice(readFileSync(file, 'utf8'));
+  const inlined = juice(readFileSync(file, 'utf8'));
+  // Belt and braces: if any build step percent-encodes the Resend merge tag
+  // (Hugo's html/template does this in href attributes), restore the literal
+  // tag so Resend detects and substitutes it.
+  return inlined.replaceAll(
+    /%7b%7b%7bRESEND_UNSUBSCRIBE_URL%7d%7d%7d/gi,
+    '{{{RESEND_UNSUBSCRIBE_URL}}}',
+  );
 }
 
 function summary(line) {


### PR DESCRIPTION
## Problem

Resend's pre-send check warned "No unsubscribe link detected" on the first draft broadcast. The template *does* include the link, but Hugo's template layer percent-encodes `{`/`}` in href attribute values — the built email contains:

```
href=%7b%7b%7bRESEND_UNSUBSCRIBE_URL%7d%7d%7d
```

Resend neither detects the tag (the warning) nor would substitute it at send time (dead unsubscribe link for recipients).

## Fix

1. **Template** (`layouts/blog/single.email.html`): emit the anchor via `printf | safeHTML`. Neither `safeHTML` nor `safeURL` on the attribute value survives Hugo's template layer — verified locally with the production build (`hugo --minify`).
2. **Safeguard** (`scripts/newsletter/send.mjs`): after juicing, decode any percent-encoded `RESEND_UNSUBSCRIBE_URL` back to the literal tag. Covers future build/minify regressions.
3. **State reset** (`.newsletter-state.json`): unrecord the SaaSpocalypse post so the next run recreates its draft with fixed HTML. The existing broken draft (`d25e16e1`) should be discarded in the Resend dashboard.

## Verification

Built this branch locally with the exact CI command and ran `send.mjs --dry-run`: the final juiced payload contains the literal `{{{RESEND_UNSUBSCRIBE_URL}}}` tag.

## After merge

Path triggers don't cover these files, so the workflow must be dispatched manually with `dry_run=false`.

---

🤖 Prepared by @zetxek via an AI coding agent.