### PR TITLE
fix(ci): include Playwright version in browser cache key

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -34,7 +34,10 @@ jobs:
         id: playwright-cache
         with:
           path: ~/.cache/ms-playwright
-          key: playwright-${{ hashFiles('package-lock.json') }}
+          # Include the Playwright version so a version bump (e.g. a new
+          # browser project added to playwright.config) invalidates a cache
+          # keyed only on the lockfile hash.
+          key: playwright-${{ steps.playwright-version.outputs.version }}-${{ hashFiles('package-lock.json') }}
 
       - name: Install dependencies
         run: npm ci
@@ -42,6 +45,14 @@ jobs:
       - name: Install Playwright browsers
         if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: npx playwright install --with-deps
+
+      - name: Install Playwright browsers (cache hit)
+        # Even on a cache hit, run a plain install without --with-deps. This
+        # is a fast no-op when all browsers are already present, but fills in
+        # any browser missing from a stale cache (e.g. one created before a
+        # new browser project was added to playwright.config).
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: npx playwright install
 
       - name: Build site
         run: hugo --minify --buildDrafts=true


### PR DESCRIPTION
## Root cause

Confirmed from a failed run today: [run 33210685660](https://github.com/zetxek/adrianmoreno.info/actions/runs/33210685660) — 26 Firefox tests failed with *"Looks like Playwright was just installed or updated"*, while 252 Chromium tests passed.

The browser cache key was:

```
playwright-${{ hashFiles('package-lock.json') }}
```

This does not include the Playwright version, and browsers are only installed on a cache **MISS**. A cache created before the Firefox project was added to `playwright.config` (with the same `package-lock.json`) is still a **HIT**, so Firefox binaries were never installed — the stale cache only had Chromium. The workflow already computes `steps.playwright-version.outputs.version` via the "Get Playwright version" step, but that output was unused in the key, which strongly suggests it was meant to be included.

## Fix

1. Cache key now includes the Playwright version: `playwright-${{ steps.playwright-version.outputs.version }}-${{ hashFiles('package-lock.json') }}`, so any Playwright version bump auto-invalidates the cache.
2. As a safety net, even on a cache **hit** we now also run `npx playwright install` (without `--with-deps`) — a fast no-op when all browsers are already present, but it fills in any browser missing from a stale/incomplete cache. The existing `--with-deps` install on cache misses is unchanged.

## Test plan

- [x] YAML parses (`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/e2e-tests.yml'))"`)
- [ ] E2E workflow run on this PR installs Firefox correctly and all tests pass

---
Prepared by @zetxek via an AI coding agent 🤖