### PR TITLE
design(books): mobile spine-open detail transition

### DIFF
--- a/assets/scss/books.scss
+++ b/assets/scss/books.scss
@@ -508,6 +508,30 @@ $book-accent: #478079;
   .book-single-cover-frame {
     transition: none !important;
   }
+
+  .book-card-link:active .book-cover-frame {
+    transform: none !important;
+    box-shadow: none !important;
+  }
+
+  .book-spine-ghost {
+    display: none !important;
+  }
+
+  .book-detail-cover,
+  .book-detail-cover-img,
+  .book-detail-content,
+  .book-detail-authors,
+  .book-detail-year,
+  .book-detail-links {
+    transform: none !important;
+    opacity: 1 !important;
+    transition: none !important;
+  }
+
+  .book-detail-cover::after {
+    display: none !important;
+  }
 }
 
 .book-meta-text {
@@ -653,6 +677,107 @@ $book-accent: #478079;
   gap: 0.75rem;
   padding-top: 0.75rem;
   border-top: 1px solid #eee;
+}
+
+// ---------------------------------------------------------------------------
+// Mobile "spine open" transition: touch press feedback on the card, the
+// fixed FLIP ghost cloned by static/js/books.js, and the modal's own
+// spine-rotate + content settle. Coarse-pointer only, and fully neutralized
+// under prefers-reduced-motion (see that query further down).
+// ---------------------------------------------------------------------------
+@media (hover: none), (pointer: coarse) {
+  .book-card-link:active .book-cover-frame {
+    transform: scale(0.96);
+    box-shadow: 0 6px 10px -6px rgba(0, 0, 0, 0.35);
+  }
+}
+
+.book-spine-ghost {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 1070; // above Bootstrap's modal (1055) and its backdrop (1050)
+  margin: 0;
+  border-radius: 6px;
+  object-fit: cover;
+  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.2);
+  pointer-events: none;
+  will-change: transform;
+}
+
+@media (hover: none), (pointer: coarse) {
+  .book-detail-modal .modal-content {
+    perspective: 1400px;
+  }
+
+  .book-detail-cover {
+    position: relative;
+    transform-origin: left center;
+    transition: transform 0.5s cubic-bezier(0.22, 1, 0.36, 1), opacity 0.5s ease-in-out;
+
+    // Spine-edge shadow, revealed only once the cover has rotated away.
+    &::after {
+      content: "";
+      position: absolute;
+      inset: 0;
+      border-radius: 6px;
+      box-shadow: inset 8px 0 14px -6px rgba(0, 0, 0, 0.45);
+      opacity: 0;
+      transition: opacity 0.4s ease-in-out;
+      pointer-events: none;
+    }
+  }
+
+  .book-detail-content,
+  .book-detail-authors,
+  .book-detail-year,
+  .book-detail-links {
+    transition: transform 0.4s ease-out, opacity 0.4s ease-out;
+  }
+
+  // Initial state right after the modal is shown: the real cover image stays
+  // hidden while the ghost flies over it, and the rest of the detail content
+  // waits off to the side instead of popping in all at once.
+  .book-detail-modal.is-opening {
+    .book-detail-cover-img {
+      opacity: 0;
+    }
+
+    .book-detail-content,
+    .book-detail-authors,
+    .book-detail-year,
+    .book-detail-links {
+      opacity: 0;
+      transform: translateX(16px);
+      transition: none;
+    }
+  }
+
+  // Once the ghost lands: the cover briefly shows the real image, then
+  // swings away like an opened paperback cover, while the rest of the
+  // content settles in behind it after a short delay.
+  .book-detail-modal.is-open {
+    .book-detail-cover-img {
+      opacity: 1;
+      transition: opacity 0.15s ease-in-out;
+    }
+
+    .book-detail-cover {
+      transform: rotateY(-92deg);
+      opacity: 0.55;
+
+      &::after {
+        opacity: 1;
+      }
+    }
+
+    .book-detail-content,
+    .book-detail-authors,
+    .book-detail-year,
+    .book-detail-links {
+      transition-delay: 0.15s;
+    }
+  }
 }
 
 .book-detail-goodreads,

--- a/assets/scss/books.scss
+++ b/assets/scss/books.scss
@@ -712,10 +712,9 @@ $book-accent: #478079;
 
   .book-detail-cover {
     position: relative;
-    transform-origin: left center;
-    transition: transform 0.5s cubic-bezier(0.22, 1, 0.36, 1), opacity 0.5s ease-in-out;
 
-    // Spine-edge shadow, revealed only once the cover has rotated away.
+    // Spine-edge shadow, revealed only once the cover has settled into its
+    // compact opened-book position.
     &::after {
       content: "";
       position: absolute;
@@ -726,6 +725,14 @@ $book-accent: #478079;
       transition: opacity 0.4s ease-in-out;
       pointer-events: none;
     }
+  }
+
+  // The rotate lives on the image itself (not the wrapping column) so the
+  // layout box it sits in can shrink to a compact thumbnail without also
+  // dragging that transform along.
+  .book-detail-cover-img {
+    transform-origin: left center;
+    transition: transform 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.15s, opacity 0.5s ease-in-out;
   }
 
   .book-detail-content,
@@ -753,22 +760,57 @@ $book-accent: #478079;
     }
   }
 
-  // Once the ghost lands: the cover briefly shows the real image, then
-  // swings away like an opened paperback cover, while the rest of the
-  // content settles in behind it after a short delay.
+  // Once the ghost lands: a compact "opened book" header — a small left-spine
+  // thumbnail beside the author/year, with the content and links settling in
+  // full-width below. Avoids the previous full-size cover box rotating away
+  // to near-nothing and leaving a large blank area.
   .book-detail-modal.is-open {
-    .book-detail-cover-img {
-      opacity: 1;
-      transition: opacity 0.15s ease-in-out;
+    .modal-body {
+      display: grid;
+      grid-template-columns: 64px 1fr;
+      column-gap: 0.85rem;
+      row-gap: 0.15rem;
+      align-items: start;
+      align-content: start;
     }
 
     .book-detail-cover {
-      transform: rotateY(-92deg);
-      opacity: 0.55;
+      grid-column: 1;
+      grid-row: 1 / 3;
+      width: 64px;
+      height: 96px;
+      margin: 0;
+      align-self: start;
 
       &::after {
         opacity: 1;
       }
+    }
+
+    .book-detail-cover-img {
+      width: 64px;
+      opacity: 1;
+      transform: rotateY(-15deg);
+    }
+
+    .book-detail-authors {
+      grid-column: 2;
+      grid-row: 1;
+      text-align: left;
+      margin-bottom: 0.2rem;
+    }
+
+    .book-detail-year {
+      grid-column: 2;
+      grid-row: 2;
+      text-align: left;
+      margin-top: 0;
+      margin-bottom: 0;
+    }
+
+    .book-detail-content,
+    .book-detail-links {
+      grid-column: 1 / -1;
     }
 
     .book-detail-content,

--- a/static/js/books.js
+++ b/static/js/books.js
@@ -208,6 +208,107 @@
     var goodreadsEl = modalEl.querySelector('.book-detail-goodreads');
     var permalinkEl = modalEl.querySelector('.book-detail-permalink');
 
+    // -------------------------------------------------------------------
+    // Mobile "spine open" transition: on coarse-pointer devices, tapping a
+    // card feels like picking the book up off the shelf. A ghost <img> is
+    // FLIP-animated from the tapped card's cover rect to the modal's cover
+    // rect (static/js/books.js has no layout access to the modal until it's
+    // shown, hence the FLIP rather than a plain CSS transition); once it
+    // lands, `.is-opening` hands off to `.is-open`, which drives the
+    // spine-rotate + content settle in books.scss. Skipped for reduced
+    // motion or fine pointers, where the modal opens exactly as before.
+    // -------------------------------------------------------------------
+    var spineGhost = null;
+
+    function removeSpineGhost() {
+      if (spineGhost && spineGhost.parentNode) spineGhost.parentNode.removeChild(spineGhost);
+      spineGhost = null;
+    }
+
+    function cleanupSpineOpen() {
+      modalEl.classList.remove('is-opening', 'is-open');
+      removeSpineGhost();
+    }
+
+    function prepareSpineOpen(trigger) {
+      var cardCover = trigger.querySelector('.book-cover');
+      if (!cardCover || !cardCover.src) return;
+
+      var rect = cardCover.getBoundingClientRect();
+      if (!rect.width || !rect.height) return;
+
+      removeSpineGhost();
+
+      var ghost = document.createElement('img');
+      ghost.src = cardCover.src;
+      ghost.alt = '';
+      ghost.setAttribute('aria-hidden', 'true');
+      ghost.className = 'book-spine-ghost';
+      ghost.style.top = rect.top + 'px';
+      ghost.style.left = rect.left + 'px';
+      ghost.style.width = rect.width + 'px';
+      ghost.style.height = rect.height + 'px';
+      document.body.appendChild(ghost);
+      spineGhost = ghost;
+
+      modalEl.classList.add('is-opening');
+    }
+
+    // FLIP: the ghost starts painted exactly over the card cover, then
+    // animates to the delta/scale needed to land on the modal cover - only
+    // `transform`/`opacity` are ever animated, so this stays compositor-only.
+    function runSpineOpen() {
+      var ghost = spineGhost;
+      if (!ghost || !ghost.animate || !coverImgEl.getBoundingClientRect) {
+        modalEl.classList.remove('is-opening');
+        modalEl.classList.add('is-open');
+        removeSpineGhost();
+        return;
+      }
+
+      var startRect = ghost.getBoundingClientRect();
+      var endRect = coverImgEl.getBoundingClientRect();
+      if (!endRect.width || !endRect.height) {
+        modalEl.classList.remove('is-opening');
+        modalEl.classList.add('is-open');
+        removeSpineGhost();
+        return;
+      }
+
+      var deltaX = endRect.left - startRect.left;
+      var deltaY = endRect.top - startRect.top;
+      var scaleX = endRect.width / startRect.width;
+      var scaleY = endRect.height / startRect.height;
+
+      var flight = ghost.animate(
+        [
+          { transform: 'translate(0px, 0px) scale(1, 1)' },
+          { transform: 'translate(' + deltaX + 'px, ' + deltaY + 'px) scale(' + scaleX + ', ' + scaleY + ')' },
+        ],
+        { duration: 380, easing: 'cubic-bezier(0.22, 1, 0.36, 1)', fill: 'forwards' }
+      );
+
+      flight.onfinish = function () {
+        if (!spineGhost) return;
+        var fade = spineGhost.animate([{ opacity: 1 }, { opacity: 0 }], { duration: 120, fill: 'forwards' });
+        fade.onfinish = function () {
+          removeSpineGhost();
+          if (modalEl.classList.contains('is-opening')) {
+            modalEl.classList.remove('is-opening');
+            modalEl.classList.add('is-open');
+          }
+        };
+      };
+    }
+
+    modalEl.addEventListener('shown.bs.modal', function () {
+      if (!modalEl.classList.contains('is-opening')) return;
+      runSpineOpen();
+    });
+
+    modalEl.addEventListener('hide.bs.modal', cleanupSpineOpen);
+    modalEl.addEventListener('hidden.bs.modal', cleanupSpineOpen);
+
     function openDetail(trigger) {
       lastTrigger = trigger;
 
@@ -259,6 +360,7 @@
           // let those navigate natively to the book page instead of opening the modal.
           if (event.detail === 0) return;
           event.preventDefault();
+          if (coarsePointer && !reduceMotion) prepareSpineOpen(trigger);
           openDetail(trigger);
         });
       });

--- a/static/js/books.js
+++ b/static/js/books.js
@@ -219,10 +219,12 @@
     // motion or fine pointers, where the modal opens exactly as before.
     // -------------------------------------------------------------------
     var spineGhost = null;
+    var spineGhostOriginRect = null; // card rect at creation time - the fixed anchor both FLIP beats measure deltas from
 
     function removeSpineGhost() {
       if (spineGhost && spineGhost.parentNode) spineGhost.parentNode.removeChild(spineGhost);
       spineGhost = null;
+      spineGhostOriginRect = null;
     }
 
     function cleanupSpineOpen() {
@@ -238,6 +240,7 @@
       if (!rect.width || !rect.height) return;
 
       removeSpineGhost();
+      spineGhostOriginRect = rect;
 
       var ghost = document.createElement('img');
       ghost.src = cardCover.src;
@@ -254,19 +257,21 @@
       modalEl.classList.add('is-opening');
     }
 
-    // FLIP: the ghost starts painted exactly over the card cover, then
-    // animates to the delta/scale needed to land on the modal cover - only
-    // `transform`/`opacity` are ever animated, so this stays compositor-only.
+    // FLIP, first beat: the ghost starts painted exactly over the card
+    // cover, then animates to the delta/scale needed to land on the
+    // full-size modal cover (the layout `.is-opening` still renders, before
+    // the compact header snaps in) - only `transform`/`opacity` are ever
+    // animated, so this stays compositor-only.
     function runSpineOpen() {
       var ghost = spineGhost;
-      if (!ghost || !ghost.animate || !coverImgEl.getBoundingClientRect) {
+      var originRect = spineGhostOriginRect;
+      if (!ghost || !originRect || !ghost.animate || !coverImgEl.getBoundingClientRect) {
         modalEl.classList.remove('is-opening');
         modalEl.classList.add('is-open');
         removeSpineGhost();
         return;
       }
 
-      var startRect = ghost.getBoundingClientRect();
       var endRect = coverImgEl.getBoundingClientRect();
       if (!endRect.width || !endRect.height) {
         modalEl.classList.remove('is-opening');
@@ -275,10 +280,10 @@
         return;
       }
 
-      var deltaX = endRect.left - startRect.left;
-      var deltaY = endRect.top - startRect.top;
-      var scaleX = endRect.width / startRect.width;
-      var scaleY = endRect.height / startRect.height;
+      var deltaX = endRect.left - originRect.left;
+      var deltaY = endRect.top - originRect.top;
+      var scaleX = endRect.width / originRect.width;
+      var scaleY = endRect.height / originRect.height;
 
       var flight = ghost.animate(
         [
@@ -290,14 +295,73 @@
 
       flight.onfinish = function () {
         if (!spineGhost) return;
+        runCompactSettleFlight(flight, deltaX, deltaY, scaleX, scaleY, originRect);
+      };
+    }
+
+    // FLIP, second beat: commits the first flight's landed transform onto
+    // the ghost as a plain inline style (so it keeps covering the full-size
+    // cover), lets `.is-open` snap the compact header/content layout in
+    // underneath, then - still anchored to the ORIGINAL card rect, so the
+    // transform stays absolute rather than relative to wherever the first
+    // beat left off - animates the same ghost the rest of the way down into
+    // the newly compact cover slot. This is what makes the header's snap
+    // into its compact grid read as the book physically closing onto its
+    // shelf-sized spine, instead of the cover just popping into place the
+    // instant `.is-open` lands.
+    function runCompactSettleFlight(flight, fromDeltaX, fromDeltaY, fromScaleX, fromScaleY, originRect) {
+      if (flight.commitStyles) {
+        try {
+          flight.commitStyles();
+        } catch (e) {
+          // Detached mid-flight or unsupported - cancel() below still leaves
+          // the ghost at its last painted frame either way.
+        }
+      }
+      if (flight.cancel) flight.cancel();
+
+      modalEl.classList.remove('is-opening');
+      modalEl.classList.add('is-open');
+
+      // Force a reflow so the compact grid layout is committed before the
+      // measurement below reads it.
+      void modalEl.offsetHeight;
+
+      var ghost = spineGhost;
+      if (!ghost || !ghost.animate) {
+        removeSpineGhost();
+        return;
+      }
+
+      var compactRect = coverImgEl.getBoundingClientRect();
+      if (!compactRect.width || !compactRect.height) {
+        removeSpineGhost();
+        return;
+      }
+
+      var toDeltaX = compactRect.left - originRect.left;
+      var toDeltaY = compactRect.top - originRect.top;
+      var toScaleX = compactRect.width / originRect.width;
+      var toScaleY = compactRect.height / originRect.height;
+
+      var settle = ghost.animate(
+        [
+          {
+            transform:
+              'translate(' + fromDeltaX + 'px, ' + fromDeltaY + 'px) scale(' + fromScaleX + ', ' + fromScaleY + ') rotate(0deg)',
+          },
+          {
+            transform:
+              'translate(' + toDeltaX + 'px, ' + toDeltaY + 'px) scale(' + toScaleX + ', ' + toScaleY + ') rotate(-10deg)',
+          },
+        ],
+        { duration: 260, easing: 'cubic-bezier(0.22, 1, 0.36, 1)', fill: 'forwards' }
+      );
+
+      settle.onfinish = function () {
+        if (!spineGhost) return;
         var fade = spineGhost.animate([{ opacity: 1 }, { opacity: 0 }], { duration: 120, fill: 'forwards' });
-        fade.onfinish = function () {
-          removeSpineGhost();
-          if (modalEl.classList.contains('is-opening')) {
-            modalEl.classList.remove('is-opening');
-            modalEl.classList.add('is-open');
-          }
-        };
+        fade.onfinish = removeSpineGhost;
       };
     }
 


### PR DESCRIPTION
## Summary
- Adds a mobile-only "spine open" transition for the book detail modal.
- Tap feedback on cards, transform-only FLIP ghost from card to modal cover, then the cover swings around its left spine while the details settle in.
- Scoped to coarse pointers; desktop behavior is unchanged.
- `prefers-reduced-motion` fully disables the effect (simple modal fade as before).

## Files
- `static/js/books.js`
- `assets/scss/books.scss`

## Verification
- `node --check static/js/books.js`
- `hugo` build passes
- Headless Chrome:
  - mobile/coarse pointer: modal reaches `is-open`, ghost cleans up, content visible
  - reduced motion: no ghost/classes, normal modal
  - desktop/fine pointer: no ghost/classes, unchanged modal

Prepared by @zetxek via an AI coding agent 🤖

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a mobile book-opening animation that transitions from the selected book card into the detail modal.
  * Added staged modal content reveals and a compact opened-book layout for mobile screens.
  * Added tactile press feedback and cover transition effects on touch devices.

* **Accessibility**
  * Added reduced-motion support to minimize or disable animations when requested.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->